### PR TITLE
Potential fix for code scanning alert no. 1: Information exposure through an exception

### DIFF
--- a/paddle/frontend/views.py
+++ b/paddle/frontend/views.py
@@ -10,6 +10,7 @@ from django.core.paginator import Paginator
 from datetime import date, datetime
 from games.models import Player, Match
 import json
+import logging
 
 def get_player_stats(request, player_id=None):
     """
@@ -433,7 +434,8 @@ def match_view(request, client=None):
             match.delete()
             return JsonResponse({"message": "Match deleted successfully"}, status=200)
         except Exception as e:
-            return JsonResponse({"error": str(e)}, status=400)
+            logging.exception("Error occurred while deleting match")
+            return JsonResponse({"error": "An error occurred while deleting the match."}, status=400)
 
     # Render the match page in GET requests
     context = {


### PR DESCRIPTION
Potential fix for [https://github.com/mrGit-bit/paddle/security/code-scanning/1](https://github.com/mrGit-bit/paddle/security/code-scanning/1)

To fix the problem, we should avoid exposing the raw exception message to the client. Instead, we should log the exception details on the server (for debugging and auditing purposes) and return a generic error message in the JSON response. This ensures that sensitive information is not leaked to the user, while still allowing developers to diagnose issues using the server logs.

**How to fix:**
- In the exception handler (lines 435-436), log the exception using Python's `logging` module.
- Return a generic error message in the JSON response, such as `"An error occurred while deleting the match."`.
- Add an import for the `logging` module at the top of the file if it is not already present.

**Files/regions to change:**
- `paddle/frontend/views.py`: Add the import, and update the exception handler in the relevant view.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
