### PR TITLE
release: promote develop to staging for v1.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ types, for example `UI/UX`, `Governance`, `Release`, `Backend`, `Data`,
 
 ## [1.9.2] - 2026-04-21
 
-- `UI/UX`: Centered ranking efficiency selector wheels by reusing the shared
-  card body flow and guarding against button cascade alignment.
+- `UI/UX`: Centered ranking efficiency selector wheels by resetting button
+  font and box styles so they reuse the shared card flow.
 - `UI/UX`: Reduced player partner name text to improve fit across player
   detail insight cards.
 - `UI/UX`: Grouped player detail ranking, recent-match, partner, and rival

--- a/paddle/frontend/static/frontend/css/styles.css
+++ b/paddle/frontend/static/frontend/css/styles.css
@@ -234,6 +234,8 @@ and replaced by an ellipsis (…) */
   cursor: pointer;
   text-align: inherit;
   align-items: stretch;
+  padding: 0;
+  font-family: inherit;
   background-color: var(--bs-body-bg);
   border-color: var(--player-scope-color);
   border-top-width: 0.25rem;

--- a/paddle/frontend/tests/test_players_pages.py
+++ b/paddle/frontend/tests/test_players_pages.py
@@ -398,7 +398,9 @@ def test_player_detail_insights_defaults_with_zero_matches(client):
         "  appearance: none;\n"
         "  cursor: pointer;\n"
         "  text-align: inherit;\n"
-        "  align-items: stretch;"
+        "  align-items: stretch;\n"
+        "  padding: 0;\n"
+        "  font-family: inherit;"
     ) in css
     assert ".player-efficiency-selector-card .card-body {\n  display: block;\n}" not in css
 


### PR DESCRIPTION
Automated release promotion for v1.9.2.

Includes corrected button cascade reset for ranking efficiency selector cards.

Source: develop
Target: staging