### PR TITLE
release: promote develop to staging for v1.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ types, for example `UI/UX`, `Governance`, `Release`, `Backend`, `Data`,
 
 ## [1.9.2] - 2026-04-21
 
+- `UI/UX`: Reordered ranking efficiency trend labels so the match-window
+  number stays visible on small screens.
 - `UI/UX`: Added an `Estadísticas` heading above the player detail insight
   card group.
 - `UI/UX`: Centered ranking efficiency selector wheels by resetting button

--- a/paddle/frontend/tests/test_players_pages.py
+++ b/paddle/frontend/tests/test_players_pages.py
@@ -326,7 +326,7 @@ def test_player_detail_insights_defaults_with_zero_matches(client):
     assert [scope["label"] for scope in insights["efficiency_scopes"]] == ["Todos", "Masc.", "Mixtos"]
     assert insights["trend_rows"] == [
         {
-            "label": "Últimos 5",
+            "label": "5 últimos",
             "wins": 0,
             "losses": 0,
             "matches": 0,
@@ -338,7 +338,7 @@ def test_player_detail_insights_defaults_with_zero_matches(client):
             "record_label": "0🏆/0🏓",
         },
         {
-            "label": "Últimos 10",
+            "label": "10 últimos",
             "wins": 0,
             "losses": 0,
             "matches": 0,
@@ -350,7 +350,7 @@ def test_player_detail_insights_defaults_with_zero_matches(client):
             "record_label": "0🏆/0🏓",
         },
         {
-            "label": "Últimos 20",
+            "label": "20 últimos",
             "wins": 0,
             "losses": 0,
             "matches": 0,
@@ -589,7 +589,7 @@ def test_player_detail_trend_windows_use_available_matches_and_round_percent(cli
     assert response.status_code == 200
     assert insights["trend_rows"] == [
         {
-            "label": "Últimos 5",
+            "label": "5 últimos",
             "wins": 4,
             "losses": 1,
             "matches": 5,
@@ -601,7 +601,7 @@ def test_player_detail_trend_windows_use_available_matches_and_round_percent(cli
             "record_label": "4🏆/5🏓",
         },
         {
-            "label": "Últimos 10",
+            "label": "10 últimos",
             "wins": 7,
             "losses": 3,
             "matches": 10,
@@ -613,7 +613,7 @@ def test_player_detail_trend_windows_use_available_matches_and_round_percent(cli
             "record_label": "7🏆/10🏓",
         },
         {
-            "label": "Últimos 20",
+            "label": "20 últimos",
             "wins": 7,
             "losses": 5,
             "matches": 12,
@@ -628,7 +628,7 @@ def test_player_detail_trend_windows_use_available_matches_and_round_percent(cli
     content = response.content.decode("utf-8")
     assert count_trend_wheels(content) == 16
     assert "Total" not in content
-    assert "Últimos 20" in content
+    assert "20 últimos" in content
     assert "4🏆/5🏓" in content
     assert "7🏆/10🏓" in content
     assert "7🏆/12🏓" in content
@@ -770,9 +770,9 @@ def test_player_detail_efficiency_scopes_use_gender_and_mixed_matches(client):
     assert mixed_scope["selector"]["matches"] == 3
     assert mixed_scope["selector"]["win_rate_percent"] == 67
     assert [row["label"] for row in mixed_scope["trend_rows"]] == [
-        "Últimos 5",
-        "Últimos 10",
-        "Últimos 20",
+        "5 últimos",
+        "10 últimos",
+        "20 últimos",
     ]
     assert mixed_scope["trend_rows"][0]["matches"] == 3
     assert mixed_scope["trend_rows"][0]["win_rate_percent"] == 67

--- a/paddle/frontend/view_modules/players.py
+++ b/paddle/frontend/view_modules/players.py
@@ -145,9 +145,9 @@ def _build_efficiency_scope(scope_key: str, label: str, match_results: list[dict
     selector_row["record_label"] = f"{selector_row['wins']}🏆/{selector_row['matches']}🏓"
 
     trend_rows = [
-        _build_efficiency_result_row("Últimos 5", results[:5]),
-        _build_efficiency_result_row("Últimos 10", results[:10]),
-        _build_efficiency_result_row("Últimos 20", results[:20]),
+        _build_efficiency_result_row("5 últimos", results[:5]),
+        _build_efficiency_result_row("10 últimos", results[:10]),
+        _build_efficiency_result_row("20 últimos", results[:20]),
     ]
     total_matches = len(results)
     for row, minimum_matches in zip(trend_rows, [1, 6, 11]):


### PR DESCRIPTION
Automated release promotion for v1.9.2.

Includes latest develop change: ranking efficiency trend labels now show the match-window number first for small screens.

Source: develop
Target: staging